### PR TITLE
Misc typo fixes

### DIFF
--- a/engine/battle/action.py
+++ b/engine/battle/action.py
@@ -45,6 +45,6 @@ class Action:
 
     def _print_spell(self, move):
         print(
-            f"{self.caster.label} casts $[secondary]'{move.name.upper()}'$ on "
+            f"{self.caster.label} casts |[secondary]'{move.name.upper()}'| on "
             f"{self.target.label}!"
         )

--- a/engine/battle/battles.py
+++ b/engine/battle/battles.py
@@ -52,6 +52,7 @@ class BaseBattle:
             pause=0.2,
         )
 
+
 class Battle(BaseBattle):
     """A battle that prints the outcome.
 
@@ -71,11 +72,6 @@ class Battle(BaseBattle):
 
         return winner
 
-    def _revive_player(self):
-        print(f"{self.savior.label} arrives at your side!")
-        for move in self.savior.job.moves:
-            action = Action(move=move, caster=self.savior, target=self.player.character)
-            action.execute()
 
 class RiggedBattle(BaseBattle):
     """A battle in which the player is guaranteed to win.

--- a/engine/battle/character.py
+++ b/engine/battle/character.py
@@ -18,4 +18,4 @@ class Character(BaseModel):
 
     @property
     def label(self):
-        return f"$[primary]Lvl {self.level} {self.job.name} {self.name.upper()}$"
+        return f"|[primary]Lvl {self.level} {self.job.name} {self.name.upper()}|"

--- a/engine/printer/__init__.py
+++ b/engine/printer/__init__.py
@@ -67,7 +67,7 @@ def input(valid_inputs: Optional[list[str]] = None) -> str:
 
 
 def _get_content_array(content: str) -> list[Content]:
-    content_arr = content.split("$")
+    content_arr = content.split("|")
 
     return [_get_content_from_string(content_string) for content_string in content_arr]
 
@@ -91,7 +91,7 @@ def _get_input_options(option_strings: list[str]) -> dict:
         shortcut = str(index + 1)
         options_map[shortcut] = {
             "shortcut": shortcut,
-            "label": f"$[primary]({shortcut})$ {option_string}",
+            "label": f"|[primary]({shortcut})| {option_string}",
             "text": option_string,
         }
 

--- a/engine/scenes/room.py
+++ b/engine/scenes/room.py
@@ -10,7 +10,7 @@ class RoomScene(Scene):
     def run(self) -> Scene:
         actions = self.room.get_actions()
 
-        print(f"\n\n{self.room.description}")
+        print(f"\n{self.room.description}")
         print("What do you want to do?")
         input_value = input(self._get_input_options(actions))
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -80,6 +80,18 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "inflect"
+version = "5.6.0"
+description = "Correctly generate plurals, singular nouns, ordinals, indefinite articles; convert numbers to words"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pygments", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+
+[[package]]
 name = "isort"
 version = "5.10.1"
 description = "A Python utility / library to sort Python imports."
@@ -259,7 +271,7 @@ python-versions = ">=3.7"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9, <3.11"
-content-hash = "f9ab47ee09b014081441310ab847173e87cdd6fde0beb9fc89e6069cb04c3357"
+content-hash = "9aef727ad5ca3f3f93c9d119fb7a4e25c730bc9ffcf000f309161d2907dc2f1d"
 
 [metadata.files]
 altgraph = [
@@ -309,6 +321,10 @@ flake8 = [
 ]
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
+]
+inflect = [
+    {file = "inflect-5.6.0-py3-none-any.whl", hash = "sha256:967d6db69932bac9f1977b8f2dd131a59147f4b56134cfc74a3f44e5adb65223"},
+    {file = "inflect-5.6.0.tar.gz", hash = "sha256:a0612e7bba1028bb7efa121bf8f012aeda9355252d01b257057fa2a8f5859cef"},
 ]
 isort = [
     {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},

--- a/prologue/alarm.py
+++ b/prologue/alarm.py
@@ -6,9 +6,10 @@ from prologue.murder import MurderScene
 
 class AlarmScene(Scene):
     def run(self):
-        print("\nThe alarm pad is beeping ominously.  Its screen reads ", end="")
-        print("[primary]ARMED", delay=0.2)
-        print("You know the alarm code, right?  Enter the code:")
+        print("\nThe alarm pad is beeping ominously. Its screen reads ", end="")
+        print("[primary]ARMED.", delay=0.2)
+        print("You know the alarm code, right?")
+        print("[info]Enter the code:")
         value = input(None)
         code_hash = hashlib.sha256(value.encode("utf-8")).hexdigest()
         if (

--- a/prologue/create_character.py
+++ b/prologue/create_character.py
@@ -13,7 +13,7 @@ p = inflect.engine()
 
 class CreateCharacterScene(Scene):
     def run(self) -> Scene:
-        print("What is your name?")
+        print("[info]What is your name?")
         player_name = input()
 
         if player_name.lower() == "qa":

--- a/prologue/create_character.py
+++ b/prologue/create_character.py
@@ -1,9 +1,14 @@
+import inflect
+
 from engine.scene import Scene
 from engine.printer import print, input
 from prologue.intro import IntroScene
 from state import game_state
 import battle.jobs as jobs
 from engine.battle.character import Character
+
+
+p = inflect.engine()
 
 
 class CreateCharacterScene(Scene):
@@ -37,7 +42,7 @@ class CreateCharacterScene(Scene):
         )
 
         self._print_selected_class(
-            f"You're an $[primary]{selected_job.name}$, {selected_job.motto}",
+            f"You're |[primary]{p.a(selected_job.name)}|, {selected_job.motto}",
             {
                 "Intelligence": selected_job.base_intelligence,
                 "Charisma": selected_job.base_charisma,
@@ -50,10 +55,10 @@ class CreateCharacterScene(Scene):
 
     def _print_class(self, name: str, ability: str):
         print(f"[primary]\n{name}", delay=0)
-        print(f"Special Ability: $[secondary]{ability}", delay=0)
+        print(f"Special Ability: |[secondary]{ability}", delay=0)
 
     def _print_selected_class(self, desc: str, stats: dict):
         print(desc)
 
         for key in list(stats.keys()):
-            print(f"[primary]{key}: $[secondary]{stats.get(key)}", delay=0)
+            print(f"[primary]{key}: |[secondary]{stats.get(key)}", delay=0)

--- a/prologue/door.py
+++ b/prologue/door.py
@@ -6,7 +6,7 @@ from prologue.elevator import ElevatorScene
 class DoorScene(Scene):
     def run(self):
         print(
-            "\nYou're in front of the heavy building door.  Both of your keys looks basically the same."
+            "\nYou're in front of the heavy building door. Both of your keys look basically the same."
         )
         print(
             "Do you want to use the silverish gold key with a nub or the gold silverish key with two nubs?"

--- a/prologue/elevator.py
+++ b/prologue/elevator.py
@@ -23,7 +23,7 @@ class ElevatorScene(Scene):
         print("[primary]ten", delay=0.3, end=" ")
         print("more times?")
         input(["Yes"])
-        print("Thankfully, the eighth time's the charm, and the key turns")
+        print("Thankfully, the eighth time's the charm, and the key turns.")
         print("The elevator lurches to life and brings you to the sixth floor.")
 
         return AlarmScene()

--- a/prologue/intro.py
+++ b/prologue/intro.py
@@ -7,7 +7,7 @@ from prologue.coffee import CoffeeScene
 class IntroScene(Scene):
     def run(self):
         print(
-            "\nIt's a warmer day than expected in New York.  You're overdressed "
+            "\nIt's a warmer day than expected in New York. You're overdressed "
             "for the day and are hot and sweaty from your train ride in from Brooklyn"
         )
         print("You arrive at the RippleMatch office bright and early.")

--- a/prologue/intro.py
+++ b/prologue/intro.py
@@ -8,7 +8,7 @@ class IntroScene(Scene):
     def run(self):
         print(
             "\nIt's a warmer day than expected in New York. You're overdressed "
-            "for the day and are hot and sweaty from your train ride in from Brooklyn"
+            "for the day and are hot and sweaty from your train ride in from Brooklyn."
         )
         print("You arrive at the RippleMatch office bright and early.")
 

--- a/prologue/murder.py
+++ b/prologue/murder.py
@@ -46,7 +46,7 @@ class MurderScene(Scene):
         print(
             "\nYou hear them breathe. You run to the VC honcho. As the life drains from their lips, they say..."
         )
-        print("[primary]\n...Dan killed me...", delay=0.2)
+        print("[danger]\n...Dan killed me...", delay=0.2)
         print("\nOh God! How could Dan do such a thing?")
         print("Wait a second. Which Dan was it? There are like a |[primary]THOUSAND| Dans at RippleMatch!")
 

--- a/prologue/murder.py
+++ b/prologue/murder.py
@@ -16,10 +16,10 @@ class MurderScene(Scene):
         print(
             "\nYou recognize them -- it's the venture capitalist from yesterday's team meeting!"
         )
-        print("\nThe were going to fund our Series B!", end=" ")
+        print("\nThey were going to fund our Series B!", end=" ")
         print("[muted](This doesn't bode well for our stock options)")
         print(
-            "\nThey sit slouched against the wall of the ROOM-brand phone booth (available at hushoffice.com)"
+            "\nThey sit slouched against the wall of the ROOM-brand phone booth (available at hushoffice.com)."
         )
         print(
             "You scream at the grusome sight. You're not sure if they're dead or alive."
@@ -44,8 +44,10 @@ class MurderScene(Scene):
                 print("You should probably help them.")
 
         print(
-            "\nYou hear them breathe. You run to the VC honcho.  As the life drains from their lips, they say..."
+            "\nYou hear them breathe. You run to the VC honcho. As the life drains from their lips, they say..."
         )
-        print("[primary]\n...Dan did it...", delay=0.5)
+        print("[primary]\n...Dan killed me...", delay=0.2)
+        print("\nOh God! How could Dan do such a thing?")
+        print("Wait a second. Which Dan was it? There are like a |[primary]THOUSAND| Dans at RippleMatch!")
 
         return SlackScene()

--- a/prologue/slack.py
+++ b/prologue/slack.py
@@ -21,4 +21,4 @@ class SlackScene(Scene):
         return ArrivalScene()
 
     def _print_slack(self, sender: str, message: str):
-        print(f"[secondary] 8:21 AM - #coreteam: $[primary]@{sender}$ - {message}")
+        print(f"[secondary] 8:21 AM - #coreteam: |[primary]@{sender}| - {message}")

--- a/prologue/slack.py
+++ b/prologue/slack.py
@@ -7,7 +7,7 @@ from state import game_state
 class SlackScene(Scene):
     def run(self):
         print("\nYou grab your phone to message #coreteam to get help.")
-        print("Enter your cry for help:")
+        print("[info]Enter your cry for help:")
         value = input()
 
         self._print_slack(game_state.player_character.name, value)  # type: ignore

--- a/prologue/title.py
+++ b/prologue/title.py
@@ -41,6 +41,6 @@ class TitleScene(Scene):
             delay=0.001,
         )
         print("Off-By-One Entertainment.  All Rights Reserved.\n")
-        print("Press enter to continue...")
+        print("[info]Press enter to continue...")
         input(None)
         return CreateCharacterScene()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ pydantic = "^1.9.0"
 black = "^22.3.0"
 flake8 = "^4.0.1"
 pyinstaller = "^5.0.1"
+inflect = "^5.6.0"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^4.0.1"

--- a/state.py
+++ b/state.py
@@ -7,6 +7,7 @@ class NOTDGameState(GameState):
         super().__init__()
         self.player_character: Optional[Character] = None
         self.pet_gunner = False
+        self.dan_i_interactions = 0
 
     @property
     def qa_mode(self):

--- a/world/office/scenes/dan_b_interview.py
+++ b/world/office/scenes/dan_b_interview.py
@@ -5,7 +5,7 @@ from state import game_state
 
 class DanBInterviewScene(Scene):
     def run(self):
-        print("[secondary]Terrible news about the dead guy.")
+        print("[secondary]Terrible news about the dead guy. Anyway...")
         print(
             "[secondary]Do you want to hear my latest recording I finished this morning?"
         )

--- a/world/office/scenes/dan_i_admission.py
+++ b/world/office/scenes/dan_i_admission.py
@@ -5,12 +5,12 @@ from world.office.scenes.final_boss import FinalBoss
 
 class DanIAdmissionScene(Scene):
     def run(self):
-        print("[secondary] OK FINE. YOU GOT ME.")
-        print("[secondary] I DID IT! AND YOU KNOW WHY?")
+        print("[secondary]OK FINE. YOU GOT ME.")
+        print("[secondary]I DID IT! AND YOU KNOW WHY?")
         print(
-            "[secondary] THAT PUNK STOLE MY ART ASSETS FOR SOME GAME COMPANY THAT HE OWNS!"
+            "[secondary]THAT PUNK STOLE MY ART ASSETS FOR SOME GAME COMPANY THAT HE OWNS!"
         )
-        print("[secondary] Why does this keep happening to me?!")
-        print("[secondary] I regret nothing, he deserved it.\n\n")
+        print("[secondary]Why does this keep happening to me?!")
+        print("[secondary]I regret nothing, he deserved it.\n\n")
 
         return FinalBoss()

--- a/world/office/scenes/dan_i_interview.py
+++ b/world/office/scenes/dan_i_interview.py
@@ -5,10 +5,20 @@ from state import game_state
 
 class DanIInterviewScene(Scene):
     def run(self):
-        print("[secondary]What was I doing this morning?")
-        print("[secondary] Umm.. stargazing?")
-        print(
-            "[secondary] Wait… it’s the morning. Erm.. NOT stargazing, but something else!"
-        )
-        print("[secondary] I don’t know, why are you bothering me?! Go away!")
+        if game_state.dan_i_interactions == 0:
+            print("[secondary]What was I doing this morning?")
+            print("[secondary]Umm.. stargazing?")
+            print(
+                "[secondary]Wait… it’s the morning. Erm.. NOT stargazing, but something else!"
+            )
+            print("[secondary]I don’t know, why are you bothering me?! Go away!")
+        elif game_state.dan_i_interactions == 1:
+            print("[secondary]Why are you looking at me so suspiciously?")
+            print("[secondary]Look. I am an |[primary]ARTIST|[secondary], a docile creature incapable of such violence.")
+            print("Gunner growls at Dan I.")
+            print("[secondary]GET OUT OF HERE YOU STUPID DOG")
+        else:
+            print("Dan I stares intently at the coffee machine, ignoring you.")
+
+        game_state.dan_i_interactions += 1
         return game_state.previous_scene

--- a/world/office/scenes/daniel_e_interview.py
+++ b/world/office/scenes/daniel_e_interview.py
@@ -6,7 +6,7 @@ from state import game_state
 class DanielEInterviewScene(Scene):
     def run(self):
         print(
-            "[secondary]Let me tell you about my morning.  I met up with Dee to determine which is faster way to get to work, my mountain bike or his motorcycle. It was a very close race but without a doubt my bike is faster and more efficient."
+            "[secondary]Let me tell you about my morning. I met up with Dee to determine which is faster way to get to work, my mountain bike or his motorcycle. It was a very close race but without a doubt my bike is faster and more efficient."
         )
         print("[secondary]Or maybe it's just me who is faster!")
         return game_state.previous_scene

--- a/world/office/scenes/daniel_e_interview.py
+++ b/world/office/scenes/daniel_e_interview.py
@@ -6,10 +6,7 @@ from state import game_state
 class DanielEInterviewScene(Scene):
     def run(self):
         print(
-            "[secondary] Let me tell you about my morning.  I met up with Dee to determine which is faster way to get to work, my mountain bike or his motorcycle."
+            "[secondary]Let me tell you about my morning.  I met up with Dee to determine which is faster way to get to work, my mountain bike or his motorcycle. It was a very close race but without a doubt my bike is faster and more efficient."
         )
-        print(
-            "[secondary] It was a very close race but without a doubt my bike is faster and more efficient."
-        )
-        print("[secondary] Or maybe it’s just me who is faster.")
+        print("[secondary]Or maybe it's just me who is faster!")
         return game_state.previous_scene

--- a/world/office/scenes/declare_murderer.py
+++ b/world/office/scenes/declare_murderer.py
@@ -16,7 +16,7 @@ class DelcareMurdererScene(Scene):
         if value == "Dan I":
           return DanIAdmissionScene()
         else:
-          print(f"You really think ${value} did it? That's quite the accusation. But if you're sure... we trust you!")
+          print(f"You really think |{value} did it? That's quite the accusation. But if you're sure... we trust you!")
           print(f"{value} is promptly fired for breach of contract, specifically Article A section C 'Do not murder any prospective investors in the company'.")
           print("Way to go detective. Hope you're sure about your choice.")
       else:

--- a/world/office/scenes/dee_interview.py
+++ b/world/office/scenes/dee_interview.py
@@ -5,13 +5,12 @@ from state import game_state
 
 class DeeInterviewScene(Scene):
     def run(self):
-        print(
-            "[secondary]So tragic to hear what happened. And now everyone is suspecting it’s me because he said it was a Dan! But… no one even calls me that?"
-        )
+        print("[secondary]So tragic to hear what happened. I can't believe one of the Dans would do something like that.")
+        print("[secondary]Wait, am I under investigation too? No one ever calls me Dan!")
         print(
             "[secondary]Also, I was having a race with Daniel E to determine the preeminent 2-wheeled vehicle! Obviously, motorcycles are best."
         )
         print("[secondary]Who won? Oh umm… I mean, ", end="")
-        print("[primary]D E F I N I T E L Y", delay=0.1, end="")
-        print("[secondary] me")
+        print("[primary]DEFINITELY", delay=0.1, end="")
+        print("[secondary] me.")
         return game_state.previous_scene

--- a/world/office/scenes/joy_interview.py
+++ b/world/office/scenes/joy_interview.py
@@ -5,15 +5,14 @@ from state import game_state
 
 class JoyInterviewScene(Scene):
     def run(self):
-        print("[secondary]Hey! I… need to talk to you about something.")
         print(
-            "[secondary]Did you know that all of the Daniels were buying out equity in RippleMatch?"
+            "[secondary]Did you know that the Dans were buying out equity in RippleMatch?"
         )
         print(
-            "[secondary]We should have seen this coming. Why else would they have hired all these Daniels?!"
+            "[secondary]We should have seen this coming. Why else would they have hired all these Dans?!"
         )
-        print("[secondary]It’s a coup!")
+        print("[secondary]It's a coup!")
         print(
-            "[secondary]Do you think they all killed the VC together? Wouldn’t surprise me."
+            "[secondary]Do you think they all killed the VC together? Wouldn't surprise me."
         )
         return game_state.previous_scene

--- a/world/office/scenes/pet_gunner.py
+++ b/world/office/scenes/pet_gunner.py
@@ -6,7 +6,7 @@ from state import game_state
 class PetGunnerScene(Scene):
     def run(self):
         game_state.pet_gunner = True
-        print("Gunner eyes you curiously, as if trying to determine what kind of person you are.")
+        print("Gunner eyes you cautiously, as if trying to determine what kind of person you are.")
         print("You want to show him you're a good person!")
         print("You give Gunner the many pets he deserves.")
         print("Gunner accepts your pets and leaves, seemingly satisfied by your impeccable character.")


### PR DESCRIPTION
This PR does the following:
- Changes the delimiter from `$` to `|`
- Adds the `inflect` package to for indefinite articles (a vs an, ie "an Engineer" vs "a Product Manager")
- Makes all non-select input prompts color `info`
- removes handful of superfluous spaces
- fixes handful of other small typos
- slight punch up of office dialogues