### PR TITLE
Add fishing. Add oscillating-meter input. Add fishing-related endings. Misc typing cleanups.

### DIFF
--- a/engine/fishing/fishing.py
+++ b/engine/fishing/fishing.py
@@ -1,0 +1,36 @@
+import random
+from typing import Optional
+
+from engine.fishing.models import Fish, FishSpecies
+
+
+class Fishing:
+    def __init__(self, species: list[FishSpecies]):
+        self.species = species
+        self.species_weights = [species.population for species in self.species]
+        self.on_hook = None
+
+    def cast(self) -> FishSpecies:
+        """Cast a line and return the species of fish on the hook."""
+        self.on_hook = random.choices(self.species, self.species_weights)[0]
+        return self.on_hook
+
+    def reel(self, reel_power: float) -> Optional[Fish]:
+        """Reel the fish in the line and return it if successful."""
+        success = (
+            self.on_hook
+            and self.on_hook.fish_group.min_reel_power
+            <= reel_power
+            <= self.on_hook.fish_group.max_reel_power
+        )
+        return (
+            Fish(
+                species=self.on_hook,
+                weight=max(
+                    0.05,
+                    random.gauss(self.on_hook.avg_weight, self.on_hook.stdev_weight),
+                ),
+            )
+            if self.on_hook and success
+            else None
+        )

--- a/engine/fishing/models.py
+++ b/engine/fishing/models.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel
+
+
+class FishGroup(BaseModel):
+    hint: str  # e.g., "This feels like a big one!"
+    min_reel_power: int  # Inclusive
+    max_reel_power: int  # Inclusive
+
+
+class FishSpecies(BaseModel):
+    name: str
+    avg_weight: float
+    stdev_weight: float
+    fish_group: FishGroup
+    population: int
+
+
+class Fish(BaseModel):
+    species: FishSpecies
+    weight: float

--- a/engine/printer/oscilating_input.py
+++ b/engine/printer/oscilating_input.py
@@ -26,7 +26,6 @@ class OscillatingMeterPrompt(threading.Thread):
     def run(self):
         current_thread = threading.currentThread()
         while self.should_run:
-            # while getattr(current_thread, "should_run", True):
             time.sleep(self.increment_length / 1000000)
 
             if getattr(current_thread, "should_run", True):
@@ -43,18 +42,15 @@ class OscillatingMeterPrompt(threading.Thread):
 
 
 def get_input_from_oscilating_meter(label: str, num_increments: int):
-    """Get the reel strength from the user."""
+    """Use the OscillatingMeterPrompt to get input from the user."""
+
     # Create and start thread to continously overwrite input prompt
     reel_input = OscillatingMeterPrompt(label, num_increments)
     reel_input.start()
 
     # Get value of meter when user presses "Enter" -- we ignore the actual input
-    # value, since we're only interested in the value of the meter
+    # value, since we're only interested in the value of the meter at the time
+    # the key was pressed.
     input(reel_input.get_prompt())
     reel_input.should_run = False
     return reel_input.meter_value
-
-
-if __name__ == "__main__":
-    print("Press ENTER to test your might")
-    print(get_input_from_oscilating_meter("POWER", 20))

--- a/engine/printer/oscilating_input.py
+++ b/engine/printer/oscilating_input.py
@@ -1,0 +1,60 @@
+import datetime
+import sys
+import threading
+import time
+
+
+class OscillatingMeterPrompt(threading.Thread):
+    """Display a meter that rises and falls every 2 seconds."""
+
+    def __init__(self, label: str, num_increments: int):
+        super().__init__()
+        self.label = label
+        self.num_increments = num_increments
+        self.increment_length = 1000000 / self.num_increments  # In microseconds
+        self.should_run = True
+
+    @property
+    def meter_value(self):
+        now = datetime.datetime.now()
+        ascending = now.second % 2 == 0
+        microseconds = now.microsecond
+
+        base_value = int(microseconds // self.increment_length)
+        return base_value + 1 if ascending else self.num_increments - base_value
+
+    def run(self):
+        current_thread = threading.currentThread()
+        while self.should_run:
+            # while getattr(current_thread, "should_run", True):
+            time.sleep(self.increment_length / 1000000)
+
+            if getattr(current_thread, "should_run", True):
+                # Now overwrite what was there in the prompt
+                sys.stdout.write("\r" + self.get_prompt())
+                sys.stdout.flush()
+
+    def get_prompt(self):
+        increments_remaining = self.num_increments - self.meter_value
+        return f'{self.label}: [{"▮" * self.meter_value}{" " * increments_remaining}]'
+
+    def set_prompt(self, new_prompt):
+        self.prompt = new_prompt
+
+
+def get_input_from_oscilating_meter(label: str, num_increments: int):
+    """Get the reel strength from the user."""
+    # Create and start thread to continously overwrite input prompt
+    reel_input = OscillatingMeterPrompt(label, num_increments)
+    reel_input.start()
+
+    # Get value of meter when user presses "Enter" -- we ignore the actual input
+    # value, since we're only interested in the value of the meter
+    input(reel_input.get_prompt())
+    reel_input.should_run = False
+    return reel_input.meter_value
+
+
+if __name__ == "__main__":
+    print("Press ENTER to test your might")
+    print(get_input_from_oscilating_meter("POWER", 20))

--- a/engine/world/room_action.py
+++ b/engine/world/room_action.py
@@ -1,8 +1,9 @@
-from typing import Union
+from typing import Callable, Union
+
 from engine.scene import Scene
 
 
 class RoomAction:
-    def __init__(self, name: str, scene: Union[Scene, callable]):
+    def __init__(self, name: str, scene: Union[Scene, Callable]):
         self.name = name
         self.scene = scene

--- a/fishing/fish_groups.py
+++ b/fishing/fish_groups.py
@@ -1,0 +1,26 @@
+from engine.fishing.models import FishGroup
+
+small_fish = FishGroup(
+    hint=(
+        "It's a small one. You'll need to use a light "
+        "touch so you don't scare it. Can you?"
+    ),
+    min_reel_power=0,
+    max_reel_power=3,
+)
+
+large_fish = FishGroup(
+    hint="It feels big! You'll need some elbow grease to reel it in. Can you?",
+    min_reel_power=8,
+    max_reel_power=10,
+)
+
+omega_fish = FishGroup(
+    hint=(
+        "It's... |[primary]ENORMOUS|! Could it be?! Yes! You're sure of "
+        "it...\nIt's the legendary |[primary]BIG CHUNGUS|!\nYou're gonna need to "
+        "muster up extra-human strength to reel in this bad boy."
+    ),
+    min_reel_power=28,
+    max_reel_power=99,
+)

--- a/fishing/fish_species.py
+++ b/fishing/fish_species.py
@@ -1,0 +1,40 @@
+from engine.fishing.models import FishSpecies
+from fishing.fish_groups import large_fish, omega_fish, small_fish
+
+rainbow_smelt = FishSpecies(
+    name="Rainbow Smelt",
+    avg_weight=0.3,
+    stdev_weight=0.1,
+    fish_group=small_fish,
+    population=20,
+)
+
+fluke = FishSpecies(
+    name="Fluke", avg_weight=4, stdev_weight=1, fish_group=large_fish, population=20
+)
+
+porgy = FishSpecies(
+    name="Porgy",
+    avg_weight=0.8,
+    stdev_weight=0.4,
+    fish_group=large_fish,
+    population=20,
+)
+
+oyster_toadfish = FishSpecies(
+    name="Oyster Toadfish",
+    avg_weight=3,
+    stdev_weight=1,
+    fish_group=large_fish,
+    population=20,
+)
+
+big_chungus = FishSpecies(
+    name="Big Chungus",
+    avg_weight=325,
+    stdev_weight=50,
+    fish_group=omega_fish,
+    population=4,
+)
+
+regular_fish = [rainbow_smelt, fluke, porgy, oyster_toadfish]

--- a/fishing/reel_input.py
+++ b/fishing/reel_input.py
@@ -1,0 +1,7 @@
+from engine.printer.oscilating_input import get_input_from_oscilating_meter
+
+
+def get_reel_power(max_power: int = 10) -> int:
+    """Get the reel strength from the user."""
+    print("Press ENTER to reel in the fish!")
+    return get_input_from_oscilating_meter("Reel power", max_power)

--- a/prologue/title.py
+++ b/prologue/title.py
@@ -1,10 +1,11 @@
+from engine.printer import input, print
 from engine.scene import Scene
-from engine.printer import print, input
 from prologue.create_character import CreateCharacterScene
+from world.office.scenes.fishing import FishingScene
 
 
 class TitleScene(Scene):
-    def run(self) -> CreateCharacterScene:
+    def run(self) -> Scene:
         print(
             """
  ███▄    █  ██▓  ▄████  ██░ ██ ▄▄▄█████▓    ▒█████    █████▒    ▄▄▄
@@ -42,5 +43,7 @@ class TitleScene(Scene):
         )
         print("Off-By-One Entertainment. All Rights Reserved.\n")
         print("[info]Press enter to continue...")
-        input(None)
+        value = input(None)
+        if value == "fishing":
+            return FishingScene()
         return CreateCharacterScene()

--- a/state.py
+++ b/state.py
@@ -1,6 +1,16 @@
 from typing import Optional
-from engine.game.state import GameState
+
+from pydantic import BaseModel
+
 from engine.battle.character import Character
+from engine.game.state import GameState
+
+
+class FishingState(BaseModel):
+    current_streak: int = 0
+    record_streak: int = 0
+    record_weight: float = 0.0
+
 
 class NOTDGameState(GameState):
     def __init__(self):
@@ -8,9 +18,7 @@ class NOTDGameState(GameState):
         self.player_character: Optional[Character] = None
         self.pet_gunner = False
         self.dan_i_interactions = 0
+        self.fishing: FishingState = FishingState()
 
-    @property
-    def qa_mode(self):
-        return self.player_name.lower() == "qa"
 
 game_state = NOTDGameState()

--- a/world/office/__init__.py
+++ b/world/office/__init__.py
@@ -1,15 +1,15 @@
-from engine.world.room_action import RoomAction
 from engine.world.place import Place
 from engine.world.room import Room
-
+from engine.world.room_action import RoomAction
 from prologue.coffee import CoffeeScene
 from state import game_state
 from world.office.scenes.dan_b_interview import DanBInterviewScene
 from world.office.scenes.dan_i_interview import DanIInterviewScene
-from world.office.scenes.daniel_e_interview import DanielEInterviewScene
 from world.office.scenes.dan_s_interview import DanSInterviewScene
+from world.office.scenes.daniel_e_interview import DanielEInterviewScene
 from world.office.scenes.declare_murderer import DelcareMurdererScene
 from world.office.scenes.dee_interview import DeeInterviewScene
+from world.office.scenes.fishing import FishingScene
 from world.office.scenes.joy_interview import JoyInterviewScene
 from world.office.scenes.pet_gunner import PetGunnerScene
 
@@ -18,11 +18,14 @@ def _get_room_actions(actions: list[RoomAction]) -> list[RoomAction]:
     def get_base_actions():
         base_actions = [
             RoomAction(name="Coffee run", scene=CoffeeScene()),
-            RoomAction(name="Declare Whodunit!", scene=DelcareMurdererScene())
+            RoomAction(name="Declare Whodunit!", scene=DelcareMurdererScene()),
+            RoomAction(name="Go fishing", scene=FishingScene()),
         ]
 
         if not game_state.pet_gunner:
-            base_actions.append(RoomAction(name="Give Gunner Pets", scene=PetGunnerScene()))
+            base_actions.append(
+                RoomAction(name="Give Gunner pets", scene=PetGunnerScene())
+            )
 
         return base_actions
 
@@ -37,50 +40,54 @@ office = Place(
             id="kitchen",
             name="Kitchen",
             description="You walk into the kitchen. The sink is filled with dirty coffee cups. There's White Claw & LaCroix cans overflowing the recycling bin. Dan I & Dan S are trying to figure out how to make coffee.",
-            get_actions=_get_room_actions([
-                RoomAction(
-                    name="Talk to Dan S",
-                    scene=DanSInterviewScene(),
-                ),
-                RoomAction(
-                    name="Talk to Dan I",
-                    scene=DanIInterviewScene(),
-                ),
-            ])
+            get_actions=_get_room_actions(
+                [
+                    RoomAction(
+                        name="Talk to Dan S",
+                        scene=DanSInterviewScene(),
+                    ),
+                    RoomAction(
+                        name="Talk to Dan I",
+                        scene=DanIInterviewScene(),
+                    ),
+                ]
+            ),
         ),
-
         Room(
             id="engineering_table",
             name="Engineering Table",
             description="You walk over to the Engineering Table. Dee and Joy are at the table discussing how to best implement Andrea's hopes & desires for the Candidate flow.",
-            get_actions=_get_room_actions([
-                RoomAction(
-                    name="Talk to Joy",
-                    scene=JoyInterviewScene(),
-                ),
-                RoomAction(
-                    name="Talk to Dee",
-                    scene=DeeInterviewScene(),
-                ),
-            ])
+            get_actions=_get_room_actions(
+                [
+                    RoomAction(
+                        name="Talk to Joy",
+                        scene=JoyInterviewScene(),
+                    ),
+                    RoomAction(
+                        name="Talk to Dee",
+                        scene=DeeInterviewScene(),
+                    ),
+                ]
+            ),
         ),
-
         Room(
             id="bathroom",
             name="Bathroom",
             description="You make your way to the bathroom. In the hall you see Lauren digging for something in the closet, boxes strewn everywhere. Daniel E & Dan B are standing in line to use the bathroom. Too much coffee for everyone this morning.",
-            get_actions=_get_room_actions([
-                RoomAction(
-                    name="Talk to Daniel E",
-                    scene=DanielEInterviewScene(),
-                ),
-                RoomAction(
-                    name="Talk to Dan B",
-                    scene=DanBInterviewScene(),
-                ),
-            ])
-        )
-    ]
+            get_actions=_get_room_actions(
+                [
+                    RoomAction(
+                        name="Talk to Daniel E",
+                        scene=DanielEInterviewScene(),
+                    ),
+                    RoomAction(
+                        name="Talk to Dan B",
+                        scene=DanBInterviewScene(),
+                    ),
+                ]
+            ),
+        ),
+    ],
 )
 
 office.default_room = office.room_map.get("engineering_table")

--- a/world/office/scenes/fishing.py
+++ b/world/office/scenes/fishing.py
@@ -1,0 +1,95 @@
+import random
+from typing import Optional
+
+from engine.fishing.fishing import Fishing
+from engine.fishing.models import Fish, FishSpecies
+from engine.printer import input, print
+from engine.printer.oscilating_input import get_input_from_oscilating_meter
+from engine.scene import Scene
+from fishing.fish_species import big_chungus, regular_fish
+from state import FishingState, game_state
+from world.office.scenes.fishing_bad_ending import FishingBadEnding
+from world.office.scenes.fishing_good_ending import FishingGoodEnding
+
+
+class FishingScene(Scene):
+
+    streak_dialogue = {
+        1: "Nice! You're getting the hang of this.",
+        2: "2 in a row! You're doing great!",
+        3: "3 in a row! Terrific!",
+        4: "That's 4 in a row! You're doing awesome!",
+        5: "5 in a row! Sick skills!!",
+        6: "6 in a row! Smokin' sexy style!!",
+    }
+    min_streak_for_big_chungus = 7
+
+    def run(self):
+        print("You arrive at the East River.")
+        print("You see fish lurking under the surface.")
+        self._print_records(game_state.fishing)
+
+        elect_to_fish = True
+        while elect_to_fish:
+            print("You cast your line.")
+
+            session = Fishing(self._get_available_fish(game_state.fishing))
+            on_hook = session.cast()
+
+            wait = random.randrange(1, 6)
+            print(f"{'.' * wait}", delay=1)
+            print("Something's biting!", pause=0.5, delay=0)
+            print(on_hook.fish_group.hint)
+
+            reel_power = self._get_reel_power(30 if on_hook == big_chungus else 10)
+            caught = session.reel(reel_power)
+
+            self._handle_catch(caught, game_state.fishing)
+            if on_hook == big_chungus:
+                if caught:
+                    return FishingGoodEnding()
+                else:
+                    return FishingBadEnding()
+            print("[info]Do you want to fish again?", delay=0)
+            elect_to_fish = input(["Yes", "No"]) == "Yes"
+
+        game_state.fishing.current_streak = 0
+        print("That's enough for now. You decide to pack it up.")
+        return game_state.previous_scene
+
+    def _get_reel_power(self, max_power: int = 10) -> int:
+        """Get the reel strength from the user."""
+        print("[info]Press ENTER to reel in the fish!", delay=0)
+        return get_input_from_oscilating_meter("Reel power", max_power)
+
+    def _handle_catch(self, caught: Optional[Fish], fishing_state: FishingState):
+        if caught is None:
+            print("Looks like it got away.")
+            fishing_state.current_streak = 0
+        else:
+            print(f"You caught a {caught.species.name}!")
+            print(f"It weighs {caught.weight:.2f} lbs.")
+            if caught.weight > fishing_state.record_weight:
+                fishing_state.record_weight = caught.weight
+                print("That's a new weight record!")
+            fishing_state.current_streak += 1
+            if fishing_state.current_streak > fishing_state.record_streak:
+                fishing_state.record_streak = fishing_state.current_streak
+            if fishing_state.current_streak:
+                default = (
+                    f"{fishing_state.current_streak} in a row! You feel like you might "
+                    "be able to catch a very special fish..."
+                )
+                print(self.streak_dialogue.get(fishing_state.current_streak, default))
+
+    def _print_records(self, fishing_state: FishingState):
+        if fishing_state.record_weight:
+            print(f"[info]Weight record: {fishing_state.record_weight:.2f} lbs.")
+        if fishing_state.record_streak:
+            print(f"[info]Streak record: {fishing_state.record_streak} fish in a row")
+
+    def _get_available_fish(self, fishing_state: FishingState) -> list[FishSpecies]:
+        available_fish = regular_fish
+        if fishing_state.current_streak >= self.min_streak_for_big_chungus:
+            available_fish.append(big_chungus)
+        return available_fish

--- a/world/office/scenes/fishing_bad_ending.py
+++ b/world/office/scenes/fishing_bad_ending.py
@@ -1,0 +1,9 @@
+from engine.printer import print
+from engine.scene import Scene
+
+
+class FishingBadEnding(Scene):
+    def run(self):
+        print("Big Chungus got away. You blew it.")
+        print("The weight of your failure is crushing.")
+        print("You no longer care about solving the murder, or anything else.")

--- a/world/office/scenes/fishing_good_ending.py
+++ b/world/office/scenes/fishing_good_ending.py
@@ -1,0 +1,16 @@
+from engine.printer import print
+from engine.scene import Scene
+
+
+class FishingGoodEnding(Scene):
+    def run(self):
+        print("Yeah baby! You caught the legendary Big Chungus!")
+        print(
+            "A crowd suddenly converges, snapping pictures and slapping you on "
+            "the back. You're on top of the world."
+        )
+        print(
+            "The mayor gives you the key to the city. You are profiled in "
+            "The New Yorker."
+        )
+        print("Solving the murder is suddenly the last thing on your mind.")


### PR DESCRIPTION
You can load directly into the fishing minigame by entering "fishing" at the `Press enter to continue...` title screen prompt.

In very rare circumstances, it's possible to get one of two fishing-related endings.

A new input method `get_input_from_oscilating_meter()` is added to `engine/printer`